### PR TITLE
Use newer CCL, cache data for faster bootup

### DIFF
--- a/Dresser/Dresser.csproj
+++ b/Dresser/Dresser.csproj
@@ -48,9 +48,7 @@
 
   <ItemGroup>
     <PackageReference Include="AllaganLib.Data" Version="2.0.0" />
-    <PackageReference Include="AllaganLib.GameSheets" Version="2.0.1" />
     <PackageReference Include="AllaganLib.Interface" Version="2.0.0" />
-    <PackageReference Include="AllaganLib.Shared" Version="2.0.0" />
     <PackageReference Include="Glamourer.Api" Version="2.8.0" />
     <ProjectReference Include="..\CriticalCommonLib\CriticalCommonLib.csproj" />
     <ProjectReference Include="..\Penumbra.GameData\Penumbra.GameData.csproj" />

--- a/Dresser/PluginServices.cs
+++ b/Dresser/PluginServices.cs
@@ -74,12 +74,10 @@ namespace Dresser {
 				BuildNpcShops = true,
 				BuildItemInfoCache = true,
 				CalculateLookups = true,
-				// ContainerBuilderHook = builder =>
-				// {
-				// 	builder.RegisterType<uint>().AsSelf().as
-				// }
+                PersistInDataShare = true,
+                CacheInDataShare = true
 			};
-			SheetManager = new SheetManager(gd, smso);
+			SheetManager = new SheetManager(dalamud, gd, smso);
 			InventoryItemFactory = new InventoryItemFactory(SheetManager, DataManager);
 
 			Context = new Context();

--- a/Dresser/packages.lock.json
+++ b/Dresser/packages.lock.json
@@ -11,19 +11,6 @@
           "CSVFile": "3.2.1"
         }
       },
-      "AllaganLib.GameSheets": {
-        "type": "Direct",
-        "requested": "[2.0.1, )",
-        "resolved": "2.0.1",
-        "contentHash": "NlKxPexDVAEZVlilfBG5IAAVxIU/VSX6INWwelo1VF/1UJSfuAtk+iS+kosoZQr3Sdn56NqIc6cbh/edc+vPBA==",
-        "dependencies": {
-          "AllaganLib.Shared": "2.0.0",
-          "Autofac": "9.0.0",
-          "Autofac.Extensions.DependencyInjection": "10.0.0",
-          "CSVFile": "3.2.1",
-          "LuminaSupplemental.Excel": "4.0.0"
-        }
-      },
       "AllaganLib.Interface": {
         "type": "Direct",
         "requested": "[2.0.0, )",
@@ -35,18 +22,6 @@
           "Autofac": "9.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "10.0.1",
           "NaturalSort.Extension": "4.4.1"
-        }
-      },
-      "AllaganLib.Shared": {
-        "type": "Direct",
-        "requested": "[2.0.0, )",
-        "resolved": "2.0.0",
-        "contentHash": "0yKPg9Vtpu7CDK2dsW6dJTcYFtZNTE3+GpakUIsX3nNmlWqZJy3ycr9ZsdMxharLcsWeKlOAkwNmJJKloMikDQ==",
-        "dependencies": {
-          "Autofac": "9.0.0",
-          "Microsoft.Extensions.Hosting": "10.0.1",
-          "Microsoft.Extensions.Hosting.Abstractions": "10.0.1",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.1"
         }
       },
       "DalamudPackager": {
@@ -66,6 +41,37 @@
         "requested": "[2.8.0, )",
         "resolved": "2.8.0",
         "contentHash": "dCxycU+lA0qraE70ZoRvM4GQAPq/K+qL/bg6t/kxKPox5GWaiunKOTXNOG2hOvgEda5WtFy6e3c9OuIM6L3faQ=="
+      },
+      "AllaganLib.GameSheets": {
+        "type": "Transitive",
+        "resolved": "2.0.6",
+        "contentHash": "gIgX/vqBfet3aZA7a48S7Va7XJH285KbbiLYiQYwSDe8m0AuPvOsyjH8rE/RcD7oPCDb2u6GpGXixEis3izYww==",
+        "dependencies": {
+          "AllaganLib.Shared": "2.0.3",
+          "Autofac": "9.0.0",
+          "Autofac.Extensions.DependencyInjection": "10.0.0",
+          "CSVFile": "3.2.1",
+          "LuminaSupplemental.Excel": "4.1.8"
+        }
+      },
+      "AllaganLib.Monitors": {
+        "type": "Transitive",
+        "resolved": "2.0.4",
+        "contentHash": "qmR44hXuKlgdUinm8GtPW6qdcB6vGBdcFi2FjYEOXPevKp9Ua5d5TLVLGo/EahjM+cl/7QrMfJFrKEdmBRG6tw==",
+        "dependencies": {
+          "AllaganLib.GameSheets": "2.0.4"
+        }
+      },
+      "AllaganLib.Shared": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "M4xbFzrhczZ9MlzAFMI2w058WMIxh/woGlwJVwbC/AodLkaUmryCQF8ilkZ41yklQT1caGmHfiUuiwM9pw1Ndw==",
+        "dependencies": {
+          "Autofac": "9.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.1",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.1",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.1"
+        }
       },
       "Autofac": {
         "type": "Transitive",
@@ -93,11 +99,11 @@
       },
       "DalaMock.Host": {
         "type": "Transitive",
-        "resolved": "4.0.0",
-        "contentHash": "wmlZL54TBH9LLrEk5bXzmEsWMIaroN8qI63slB2nYIM9wDOeLQ59e4a6r3XViJ+BIWiO2ViK04jGvdr+Cz5U5g==",
+        "resolved": "4.0.5",
+        "contentHash": "a049w3CYLybukIJjLgnuG76Xixrcq2UkR/Ux5nqEc6fE/zaRPlsUeNSKjYLDXXBinJpfMNOgazTZ+0bH0rtkYQ==",
         "dependencies": {
           "Autofac.Extensions.DependencyInjection": "10.0.0",
-          "DalaMock.Shared": "4.0.0",
+          "DalaMock.Shared": "4.0.5",
           "Microsoft.Extensions.Hosting": "10.0.1",
           "Microsoft.Extensions.Hosting.Abstractions": "10.0.1",
           "Microsoft.Extensions.ObjectPool": "10.0.1"
@@ -105,8 +111,8 @@
       },
       "DalaMock.Shared": {
         "type": "Transitive",
-        "resolved": "4.0.0",
-        "contentHash": "31CIXD0QkMryDkpFlVZb7otbQh4+kqxgQfzUT9WI87CKXc3/XQYDC9V0kIo5QTd5RHNImLyXABD5xDvY5MC92w==",
+        "resolved": "4.0.5",
+        "contentHash": "9fsAF8IiprUcYIPal77mrGouWqexAkvdpDtbL0HH6Ky3C8mCD+6Hcp0pMpii+bsijqVbyp8NauIQ4bWFajRi2g==",
         "dependencies": {
           "Autofac": "9.0.0",
           "Microsoft.Extensions.Hosting": "10.0.1",
@@ -135,8 +141,8 @@
       },
       "LuminaSupplemental.Excel": {
         "type": "Transitive",
-        "resolved": "4.0.0",
-        "contentHash": "tU4otOkloGeN7R5C23bWXEQoP2ZInxQefcW1GmlXcTCffJ/JQWO11kaZ106A8jB8IDJY5ZA5x07+Z7RJSIK/ig==",
+        "resolved": "4.1.8",
+        "contentHash": "DItgH9A3c6RO7iCeyzss5yDTp6LktepZSDLsZPM3KJX847F4MTlEt8q8UTfrURM1cO1SyzftUoncoCtOqFDcFg==",
         "dependencies": {
           "CSVFile": "3.2.1",
           "CsvHelper": "30.0.1",
@@ -455,9 +461,10 @@
       "criticalcommonlib": {
         "type": "Project",
         "dependencies": {
-          "AllaganLib.GameSheets": "[2.0.1, )",
-          "AllaganLib.Shared": "[2.0.0, )",
-          "DalaMock.Host": "[4.0.0, )",
+          "AllaganLib.GameSheets": "[2.0.6, )",
+          "AllaganLib.Monitors": "[2.0.4, )",
+          "AllaganLib.Shared": "[2.0.3, )",
+          "DalaMock.Host": "[4.0.5, )",
           "Humanizer.Core": "[3.0.1, )",
           "Microsoft.Extensions.Hosting": "[10.0.1, )",
           "NaturalSort.Extension": "[4.4.1, )",


### PR DESCRIPTION
- This switches to the real CCL which also gets updates to GameSheets quite often so you'll be able to just update that and be on the latest version of everything source wise
- The new version of AllaganLib.Gamesheets does some caching in respect to the data it needs for shops/npcs and it's shared amongst every plugin using it, I've turned it on which should make any plugin after the first to load that's using the library boot faster(also helps when developing because it reloads faster)